### PR TITLE
Match import name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install vue-splitpane
 import splitPane from 'vue-splitpane'
 
 # use as global component
-Vue.component('split-pane', VueSplitPane);
+Vue.component('split-pane', splitPane);
 ```
 
 ### Example


### PR DESCRIPTION
Fix `VueSplitPane` in the component section to match the import statement.