### PR TITLE
Fix：slot 传入 iFrame 拖动失效问题

### DIFF
--- a/src/split-pane/index.vue
+++ b/src/split-pane/index.vue
@@ -10,7 +10,7 @@
     <pane class="splitter-pane splitter-paneR" :split="split" :style="{ [type]: 100-percent+'%'}">
       <slot name="paneR"></slot>
     </pane>
-
+    <div class="vue-splitter-container-mask" v-if="active"></div>
   </div>
 </template>
 
@@ -124,5 +124,14 @@
 .vue-splitter-container {
   height: 100%;
   position: relative;
+}
+
+.vue-splitter-container-mask {
+  z-index: 9999;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 </style>


### PR DESCRIPTION
描述：
当slot传入的dom为 iframe（如：ueditor 富文本编辑器）时，拖动 resizer 到 iftame 区域时 mousemove 事件会被捕获，不会继续向上冒泡，导致拖动失效。使用@mousemove.capture="onMouseMove"并不能解决。

解决方案：
增加一个隐藏的遮罩层，当状态为acitve的时候显示出来，防止mousemove 事件与 slot内部dom 事件相互影响。
