### PR TITLE
Fix wrong cursor style.

### DIFF
--- a/src/split-pane/index.vue
+++ b/src/split-pane/index.vue
@@ -43,7 +43,7 @@
         return this.active ? 'none' : ''
       },
       cursor() {
-        return this.active ? 'col-resize' : ''
+        return this.active ? (this.split === 'vertical' ? 'col-resize' : 'row-resize') : ''
       }
     },
     watch: {


### PR DESCRIPTION
Cursor may flip to col-resize when I dragging a horizontal split bar.

In most situation, this bug won't appear. I don't know how to reproduce it.